### PR TITLE
Add ocaml-mdx verification of the tutorials

### DIFF
--- a/data/tutorial/backend.md
+++ b/data/tutorial/backend.md
@@ -291,7 +291,7 @@ module KV: Irmin.KV_MAKER = functor (C: Irmin.Contents.S) ->
 
 We also have to provide a configuration for our backend specifying the parameters needed when initialising a store. In our example, we start with an empty configuration, which comes with `root` as a parameter. We can then instantiate the store and create a repo:
 
-```ocaml
+```ocaml skip
 let config ?(config = Irmin.Private.Conf.empty) ?root () =
   let module C = Irmin.Private.Conf in
   C.add config C.root root
@@ -310,7 +310,7 @@ $ redis-server /usr/local/etc/redis.conf
 
 or we can run the server from OCaml:
 
-```ocaml
+```ocaml skip
 let start_server () =
   let config = [("port", ["6379"]); ("daemonize", ["no"])] in
   let server = Hiredis.Shell.Server.start ~config 6379 in

--- a/data/tutorial/dune
+++ b/data/tutorial/dune
@@ -6,7 +6,7 @@
  (action
   (with-stdout-to
    %{targets}
-   (bash "echo %{markdown} | xargs --max-args=1 ocaml-mdx pp"))))
+   (bash "echo %{markdown} | xargs -n 1 ocaml-mdx pp"))))
 
 (test
  (name mdx)

--- a/data/tutorial/dune
+++ b/data/tutorial/dune
@@ -10,4 +10,4 @@
 
 (test
  (name mdx)
- (libraries irmin irmin-unix digestif.ocaml lwt hiredis))
+ (libraries irmin irmin-unix lwt hiredis))

--- a/data/tutorial/dune
+++ b/data/tutorial/dune
@@ -1,0 +1,13 @@
+(rule
+ (targets mdx.ml)
+ (deps
+  (:markdown
+   (glob_files *.md)))
+ (action
+  (with-stdout-to
+   %{targets}
+   (bash "echo %{markdown} | xargs --max-args=1 ocaml-mdx pp"))))
+
+(test
+ (name mdx)
+ (libraries irmin irmin-unix digestif.ocaml lwt hiredis))

--- a/data/tutorial/getting-started.md
+++ b/data/tutorial/getting-started.md
@@ -154,7 +154,7 @@ Each of these also has an `_exn` variant which may raise an exception instead of
 
 For example, you can pull a repo and list the files in the root of the project:
 
-```ocaml
+```ocaml skip
 open Irmin_unix
 module Git_mem_store = Git.Mem.KV(Irmin.Contents.String)
 module Sync = Irmin.Sync(Git_mem_store)

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.11)
+(name irmin-website)

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -25,7 +25,7 @@ module.exports = {
             options: {
               classPrefix: "language-",
               inlineCodeMarker: null,
-              aliases: { shell: "shell-session" },
+              aliases: { shell: "shell-session", ocamlskip: "ocaml" },
               showLineNumbers: false,
               noInlineHighlight: true
             }

--- a/irmin-website.opam
+++ b/irmin-website.opam
@@ -18,6 +18,7 @@ depends: [
   "dune"       {build & >= "1.7.0"}
   "irmin"
   "irmin-unix"
+  "digestif"   {= "0.7.3"}
   "mdx"
   "lwt"
   "hiredis"

--- a/irmin-website.opam
+++ b/irmin-website.opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name:         "irmin-website"
+synopsis:     "Public homepage of Irmin"
+maintainer:   "Craig Ferguson <me@craigfe.io>"
+authors:      ["Craig Ferguson <me@craigfe.io>"]
+homepage:     "https://github.com/tarides/irmin.io"
+bug-reports:  "https://github.com/tarides/irmin.io/issues"
+dev-repo:     "git+https://github.com/tarides/irmin.io.git"
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.06.0"}
+  "dune"       {build & >= "1.7.0"}
+  "irmin"
+  "irmin-unix"
+  "mdx"
+  "lwt"
+  "hiredis"
+]
+
+pin-depends: [
+  ["irmin.dev"         "git+https://github.com/mirage/irmin.git"]
+  ["irmin-unix.dev"    "git+https://github.com/mirage/irmin.git"]
+  ["irmin-mem.dev"     "git+https://github.com/mirage/irmin.git"]
+  ["irmin-git.dev"     "git+https://github.com/mirage/irmin.git"]
+  ["irmin-http.dev"    "git+https://github.com/mirage/irmin.git"]
+  ["irmin-fs.dev"      "git+https://github.com/mirage/irmin.git"]
+  ["irmin-graphql.dev" "git+https://github.com/mirage/irmin.git"]
+]

--- a/irmin-website.opam
+++ b/irmin-website.opam
@@ -31,4 +31,5 @@ pin-depends: [
   ["irmin-http.dev"    "git+https://github.com/mirage/irmin.git"]
   ["irmin-fs.dev"      "git+https://github.com/mirage/irmin.git"]
   ["irmin-graphql.dev" "git+https://github.com/mirage/irmin.git"]
+  ["mdx.dev"           "git+https://github.com/realworldocaml/mdx.git"]
 ]

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "serve": "gatsby serve",
     "develop": "gatsby develop",
     "start": "npm run develop",
-    "format": "prettier --write package.json \"*.js\" \"{src,data}/**/*.{css,js,json,md}\"",
-    "lint": "prettier --check package.json \"*.js\" \"{src,data}/**/*.{css,js,json,md}\"",
+    "format": "prettier --write \"*.{js,json,yml}\" \"{src,data}/**/*.{css,js,json,md,yml}\"",
+    "lint": "prettier --check \"*.{js,json,yml}\" \"{src,data}/**/*.{css,js,json,md,yml}\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds opam/dune configuration to run `ocaml-mdx pp` over the tutorials (and then run the result). As a side-effect, also verifies that the main example on the homepage compiles.