### PR TITLE
Update repo location to mirage/irmin.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Irmin website &nbsp;&nbsp; [![Travis status][travis-img]][travis]
 
-[travis]: https://travis-ci.org/tarides/irmin.io/branches
-[travis-img]: https://travis-ci.org/tarides/irmin.io.svg?branch=master
+[travis]: https://travis-ci.org/mirage/irmin.io/branches
+[travis-img]: https://travis-ci.org/mirage/irmin.io.svg?branch=master
 
 This repository contains the source code for [irmin.io][irmin.io], which describes the [Irmin
 distributed database][irmin] and contains tutorials for getting started with Irmin.
@@ -16,7 +16,7 @@ The website is generated using [GatsbyJS][gatsby]. The following commands run an
 website locally:
 
 ```shell
-git clone https://github.com/tarides/irmin.io
+git clone https://github.com/mirage/irmin.io
 cd irmin.io
 
 yarn install    # Install build dependencies
@@ -35,6 +35,6 @@ but beware that this may show stale artefacts.
 
 [irmin]: https://github.com/mirage/irmin/
 [irmin.io]: https://irmin.io/
-[tutorial-dir]: https://github.com/tarides/irmin.io/tree/master/data/tutorial/
+[tutorial-dir]: https://github.com/mirage/irmin.io/tree/master/data/tutorial/
 [prettier]: https://github.com/prettier/prettier/
 [gatsby]: https://www.gatsbyjs.org/

--- a/data/tutorial/backend.md
+++ b/data/tutorial/backend.md
@@ -4,27 +4,21 @@ title: "Writing a storage backend"
 ---
 
 This section illustrates how to write a custom storage backend for Irmin using a
-simplified implementation of
-[irmin-redis](https://github.com/zshipko/irmin-redis) as an example.
-`irmin-redis` uses a Redis server to store Irmin data.
+simplified implementation of [irmin-redis] as an example. `irmin-redis` uses a
+Redis server to store Irmin data.
 
 Unlike writing a [custom datatype](Contents.html), there is not a tidy way of
 doing this. A backend is built from a number of lower level stores, where each
 store implements some of the operations needed by the backend. In this example
-we instantiate functors of type
-[Irmin.CONTENT_ADDRESSABLE_STORE_MAKER](https://mirage.github.io/irmin/irmin/Irmin/module-type-CONTENT_ADDRESSABLE_STORE_MAKER/index.html)
-(for the block store) and
-[Irmin.ATOMIC_WRITE_STORE_MAKER](https://mirage.github.io/irmin/irmin/Irmin/module-type-ATOMIC_WRITE_STORE_MAKER/index.html)
-(for the tag store). The two are used in creating a module of type
-[Irmin.S_MAKER](https://mirage.github.io/irmin/irmin/Irmin/module-type-S_MAKER/index.html),
-which is in turn used in a functor of type
-[Irmin.KV_MAKER](https://mirage.github.io/irmin/irmin/Irmin/module-type-KV_MAKER/index.html).
+we instantiate functors of type [Irmin.CONTENT_ADDRESSABLE_STORE_MAKER] (for the
+block store) and [Irmin.ATOMIC_WRITE_STORE_MAKER] (for the tag store). The two
+are used in creating a module of type [Irmin.S_MAKER], which is in turn used in
+a functor of type [Irmin.KV_MAKER].
 
 ## Redis client
 
-This example uses the [hiredis](https://github.com/zshipko/ocaml-hiredis)
-package to create connections, send and receive data from Redis servers. It is
-available on [opam](https://github.com/ocaml/opam) under the same name.
+This example uses the [hiredis] package to create connections, send and receive
+data from Redis servers. It is available on [opam] under the same name.
 
 ## The readonly store
 
@@ -114,9 +108,8 @@ end
 
 ### The content-addressable store
 
-Next is the content-addressable
-([CONTENT_ADDRESSABLE_STORE](https://mirage.github.io/irmin/irmin/Irmin/module-type-CONTENT_ADDRESSABLE_STORE/index.html))
-interface - the majority of the required methods can be inherited from `Helper`!
+Next is the content-addressable ([Irmin.CONTENT_ADDRESSABLE_STORE]) interface -
+the majority of the required methods can be inherited from `Helper`!
 
 ```ocaml
 module Content_addressable : Irmin.CONTENT_ADDRESSABLE_STORE_MAKER = functor
@@ -163,10 +156,8 @@ end
 
 ## The atomic-write store
 
-The
-[ATOMIC_WRITE_STORE](https://mirage.github.io/irmin/irmin/Irmin/module-type-ATOMIC_WRITE_STORE/index.html)
-has many more types and values that need to be defined than the previous
-examples, but luckily this is the last step!
+The [Irmin.ATOMIC_WRITE_STORE] has many more types and values that need to be
+defined than the previous examples, but luckily this is the last step!
 
 To start off we can use the `Helper` functor defined above:
 
@@ -181,8 +172,7 @@ module Atomic_write: Irmin.ATOMIC_WRITE_STORE_MAKER = functor
 There are a few types we need to declare next. `key` and `value` should match
 `H.key` and `H.value` and `watch` is used to declare the type of the watcher --
 this is used to send notifications when the store has been updated.
-[irmin-watcher](https://github.com/mirage/irmin-watcher) has some more
-information on watchers.
+[irmin-watcher] has some more information on watchers.
 
 ```ocaml
   module W = Irmin.Private.Watch.Make(K)(V)
@@ -373,3 +363,16 @@ let start_server () =
 
 let stop_server server () = Hiredis.Shell.Server.stop server
 ```
+
+<!-- prettier-ignore-start -->
+[Irmin.S_MAKER]: https://mirage.github.io/irmin/irmin/Irmin/module-type-S_MAKER/index.html
+[Irmin.KV_MAKER]: https://mirage.github.io/irmin/irmin/Irmin/module-type-KV_MAKER/index.html
+[Irmin.CONTENT_ADDRESSABLE_STORE_MAKER]: https://mirage.github.io/irmin/irmin/Irmin/module-type-CONTENT_ADDRESSABLE_STORE_MAKER/index.html
+[Irmin.ATOMIC_WRITE_STORE]: https://mirage.github.io/irmin/irmin/Irmin/module-type-ATOMIC_WRITE_STORE/index.html
+[Irmin.ATOMIC_WRITE_STORE_MAKER]: https://mirage.github.io/irmin/irmin/Irmin/module-type-ATOMIC_WRITE_STORE_MAKER/index.html
+
+[irmin-watcher]: https://github.com/mirage/irmin-watcher
+[irmin-redis]: https://github.com/zshipko/irmin-redis
+[hiredis]: https://github.com/zshipko/ocaml-hiredis
+[opam]: https://github.com/ocaml/opam
+<!-- prettier-ignore-end -->

--- a/data/tutorial/backend.md
+++ b/data/tutorial/backend.md
@@ -3,18 +3,35 @@ path: "/tutorial/backend"
 title: "Writing a storage backend"
 ---
 
-This section illustrates how to write a custom storage backend for Irmin using a simplified implementation of [irmin-redis](https://github.com/zshipko/irmin-redis) as an example. `irmin-redis` uses a Redis server to store Irmin data.
+This section illustrates how to write a custom storage backend for Irmin using a
+simplified implementation of
+[irmin-redis](https://github.com/zshipko/irmin-redis) as an example.
+`irmin-redis` uses a Redis server to store Irmin data.
 
-Unlike writing a [custom datatype](Contents.html), there is not a tidy way of doing this. A backend is built from a number of lower level stores, where each store implements some of the operations needed by the backend.
-In this example we instantiate functors of type [Irmin.CONTENT_ADDRESSABLE_STORE_MAKER](https://mirage.github.io/irmin/irmin/Irmin/module-type-CONTENT_ADDRESSABLE_STORE_MAKER/index.html) (for the block store) and [Irmin.ATOMIC_WRITE_STORE_MAKER](https://mirage.github.io/irmin/irmin/Irmin/module-type-ATOMIC_WRITE_STORE_MAKER/index.html) (for the tag store). The two are used in creating a module of type [Irmin.S_MAKER](https://mirage.github.io/irmin/irmin/Irmin/module-type-S_MAKER/index.html), which is in turn used in a functor of type [Irmin.KV_MAKER](https://mirage.github.io/irmin/irmin/Irmin/module-type-KV_MAKER/index.html).
+Unlike writing a [custom datatype](Contents.html), there is not a tidy way of
+doing this. A backend is built from a number of lower level stores, where each
+store implements some of the operations needed by the backend. In this example
+we instantiate functors of type
+[Irmin.CONTENT_ADDRESSABLE_STORE_MAKER](https://mirage.github.io/irmin/irmin/Irmin/module-type-CONTENT_ADDRESSABLE_STORE_MAKER/index.html)
+(for the block store) and
+[Irmin.ATOMIC_WRITE_STORE_MAKER](https://mirage.github.io/irmin/irmin/Irmin/module-type-ATOMIC_WRITE_STORE_MAKER/index.html)
+(for the tag store). The two are used in creating a module of type
+[Irmin.S_MAKER](https://mirage.github.io/irmin/irmin/Irmin/module-type-S_MAKER/index.html),
+which is in turn used in a functor of type
+[Irmin.KV_MAKER](https://mirage.github.io/irmin/irmin/Irmin/module-type-KV_MAKER/index.html).
 
 ## Redis client
 
-This example uses the [hiredis](https://github.com/zshipko/ocaml-hiredis) package to create connections, send and receive data from Redis servers. It is available on [opam](https://github.com/ocaml/opam) under the same name.
+This example uses the [hiredis](https://github.com/zshipko/ocaml-hiredis)
+package to create connections, send and receive data from Redis servers. It is
+available on [opam](https://github.com/ocaml/opam) under the same name.
 
 ## The readonly store
 
-The process for writing a backend for Irmin requires implementing a few functors -- to accomplish this, we can start off by writing a helper module that provides a generic implementation that can be re-used by the content-addressable store and the atomic-write store:
+The process for writing a backend for Irmin requires implementing a few functors
+-- to accomplish this, we can start off by writing a helper module that provides
+a generic implementation that can be re-used by the content-addressable store
+and the atomic-write store:
 
 - `t`: the store type
 - `key`: the key type
@@ -38,9 +55,16 @@ Additionally, it requires a few functions:
 - `mem`: checks whether or not a key exists
 - `find`: returns the value associated with a key (if it exists)
 
-A single Redis instance provides all of the different types of stores within an Irmin database. This entails two issues that we have to address in our implementation. First, some functions (namely `list`) need to differentiate between entries of the atomic-write store and ones of other stores. We use two prefixes ,`"obj"` and `"data"`, added at the beginning of a key, to identify the store type in Redis.
+A single Redis instance provides all of the different types of stores within an
+Irmin database. This entails two issues that we have to address in our
+implementation. First, some functions (namely `list`) need to differentiate
+between entries of the atomic-write store and ones of other stores. We use two
+prefixes ,`"obj"` and `"data"`, added at the beginning of a key, to identify the
+store type in Redis.
 
-The second issue is that the requests to the server from one store can interleave with the requests of another store (as for example in the `batch` function). Therefore, to prevent conflicts, each store has its own Redis client.
+The second issue is that the requests to the server from one store can
+interleave with the requests of another store (as for example in the `batch`
+function). Therefore, to prevent conflicts, each store has its own Redis client.
 
 ```ocaml
   let v prefix config =
@@ -62,7 +86,8 @@ The second issue is that the requests to the server from one store can interleav
     Lwt.return (root, client)
 ```
 
-`mem` is implemented using the `EXISTS` command, which checks for the existence of a key in Redis:
+`mem` is implemented using the `EXISTS` command, which checks for the existence
+of a key in Redis:
 
 ```ocaml
   let mem (prefix, client) key =
@@ -72,7 +97,8 @@ The second issue is that the requests to the server from one store can interleav
       | _ -> Lwt.return_false
 ```
 
-`find` uses the `GET` command to retrieve the key, if one isn't found or can't be decoded correctly then `find` returns `None`:
+`find` uses the `GET` command to retrieve the key, if one isn't found or can't
+be decoded correctly then `find` returns `None`:
 
 ```ocaml
   let find (prefix, client) key =
@@ -88,7 +114,9 @@ end
 
 ### The content-addressable store
 
-Next is the content-addressable ([CONTENT_ADDRESSABLE_STORE](https://mirage.github.io/irmin/irmin/Irmin/module-type-CONTENT_ADDRESSABLE_STORE/index.html)) interface - the majority of the required methods can be inherited from `Helper`!
+Next is the content-addressable
+([CONTENT_ADDRESSABLE_STORE](https://mirage.github.io/irmin/irmin/Irmin/module-type-CONTENT_ADDRESSABLE_STORE/index.html))
+interface - the majority of the required methods can be inherited from `Helper`!
 
 ```ocaml
 module Content_addressable : Irmin.CONTENT_ADDRESSABLE_STORE_MAKER = functor
@@ -99,7 +127,8 @@ module Content_addressable : Irmin.CONTENT_ADDRESSABLE_STORE_MAKER = functor
   let v = v "obj"
 ```
 
-This module needs an `add` function, which takes a value, hashes it, stores the association and returns the hash:
+This module needs an `add` function, which takes a value, hashes it, stores the
+association and returns the hash:
 
 ```ocaml
   let add (prefix, client) value =
@@ -112,7 +141,8 @@ This module needs an `add` function, which takes a value, hashes it, stores the 
   let unsafe_add t _ v = add t v >|= ignore
 ```
 
-Then a `batch` function, which can be used to group writes together. We will use the most basic implementation:
+Then a `batch` function, which can be used to group writes together. We will use
+the most basic implementation:
 
 ```ocaml
   let batch (prefix, client) f =
@@ -123,8 +153,8 @@ Then a `batch` function, which can be used to group writes together. We will use
 
 ```
 
-Finally, we must provide a `close` function to free any resources held by the backend. In our case,
-this can be a simple no-op:
+Finally, we must provide a `close` function to free any resources held by the
+backend. In our case, this can be a simple no-op:
 
 ```ocaml
   let close _t = Lwt.return_unit
@@ -133,7 +163,10 @@ end
 
 ## The atomic-write store
 
-The [ATOMIC_WRITE_STORE](https://mirage.github.io/irmin/irmin/Irmin/module-type-ATOMIC_WRITE_STORE/index.html) has many more types and values that need to be defined than the previous examples, but luckily this is the last step!
+The
+[ATOMIC_WRITE_STORE](https://mirage.github.io/irmin/irmin/Irmin/module-type-ATOMIC_WRITE_STORE/index.html)
+has many more types and values that need to be defined than the previous
+examples, but luckily this is the last step!
 
 To start off we can use the `Helper` functor defined above:
 
@@ -145,7 +178,11 @@ module Atomic_write: Irmin.ATOMIC_WRITE_STORE_MAKER = functor
   module H = Helper(K)(V)
 ```
 
-There are a few types we need to declare next. `key` and `value` should match `H.key` and `H.value` and `watch` is used to declare the type of the watcher -- this is used to send notifications when the store has been updated. [irmin-watcher](https://github.com/mirage/irmin-watcher) has some more information on watchers.
+There are a few types we need to declare next. `key` and `value` should match
+`H.key` and `H.value` and `watch` is used to declare the type of the watcher --
+this is used to send notifications when the store has been updated.
+[irmin-watcher](https://github.com/mirage/irmin-watcher) has some more
+information on watchers.
 
 ```ocaml
   module W = Irmin.Private.Watch.Make(K)(V)
@@ -155,7 +192,8 @@ There are a few types we need to declare next. `key` and `value` should match `H
   type watch = W.watch                  (* Watch type *)
 ```
 
-The `watches` variable defined below creates a context used to track active watches.
+The `watches` variable defined below creates a context used to track active
+watches.
 
 ```ocaml
   let watches = W.v ()
@@ -169,14 +207,16 @@ Again, we need a `v` function for creating a value of type `t`:
     Lwt.return {t; w = watches }
 ```
 
-The next few functions (`find` and `mem`) are just wrappers around the implementations in `H`:
+The next few functions (`find` and `mem`) are just wrappers around the
+implementations in `H`:
 
 ```ocaml
   let find t = H.find t.t
   let mem t  = H.mem t.t
 ```
 
-A few more simple functions: `watch_key`, `watch` and `unwatch`, used to created or destroy watches:
+A few more simple functions: `watch_key`, `watch` and `unwatch`, used to created
+or destroy watches:
 
 ```ocaml
   let watch_key t key = W.watch_key t.w key
@@ -189,10 +229,12 @@ We will need to implement a few more functions:
 - `list`, lists files at a specific path.
 - `set`, writes a value to the store.
 - `remove`, deletes a value from the store.
-- `test_and_set`, modifies a key only if the `test` value matches the current value for the given key.
+- `test_and_set`, modifies a key only if the `test` value matches the current
+  value for the given key.
 - `close`, closes any resources held by the backend.
 
-The `list` implementation will get a list of keys from Redis using the `KEYS` command then convert them from strings to `Store.key` values:
+The `list` implementation will get a list of keys from Redis using the `KEYS`
+command then convert them from strings to `Store.key` values:
 
 ```ocaml
   let list {t = (prefix, client); _} =
@@ -208,7 +250,9 @@ The `list` implementation will get a list of keys from Redis using the `KEYS` co
       | _ -> Lwt.return []
 ```
 
-`set` just encodes the keys and values as strings, then uses the Redis `SET` command to store them. As this operation updates the store, the watchers have to be notified:
+`set` just encodes the keys and values as strings, then uses the Redis `SET`
+command to store them. As this operation updates the store, the watchers have to
+be notified:
 
 ```ocaml
   let set {t = (prefix, client); w} key value =
@@ -219,7 +263,8 @@ The `list` implementation will get a list of keys from Redis using the `KEYS` co
       | _ -> Lwt.return_unit
 ```
 
-`remove` uses the Redis `DEL` command to remove stored values and then notifies the watchers:
+`remove` uses the Redis `DEL` command to remove stored values and then notifies
+the watchers:
 
 ```ocaml
   let remove {t = (prefix, client); w} key =
@@ -228,7 +273,9 @@ The `list` implementation will get a list of keys from Redis using the `KEYS` co
       W.notify w key None
 ```
 
-`test_and_set` will modify a key if the current value is equal to `test`. This requires an atomic check and set, which can be done using `WATCH`, `MULTI` and `EXEC` in Redis:
+`test_and_set` will modify a key if the current value is equal to `test`. This
+requires an atomic check and set, which can be done using `WATCH`, `MULTI` and
+`EXEC` in Redis:
 
 ```ocaml
   let test_and_set t key ~test ~set:set_value =
@@ -275,7 +322,8 @@ Finally, we need another `close` function:
 end
 ```
 
-Now, let's use the `Make` and `KV` functors for creating Redis-backed Irmin stores:
+Now, let's use the `Make` and `KV` functors for creating Redis-backed Irmin
+stores:
 
 ```ocaml
 module Make: Irmin.S_MAKER = Irmin.Make (Content_addressable) (Atomic_write)
@@ -289,7 +337,10 @@ module KV: Irmin.KV_MAKER = functor (C: Irmin.Contents.S) ->
     (Irmin.Hash.SHA1)
 ```
 
-We also have to provide a configuration for our backend specifying the parameters needed when initialising a store. In our example, we start with an empty configuration, which comes with `root` as a parameter. We can then instantiate the store and create a repo:
+We also have to provide a configuration for our backend specifying the
+parameters needed when initialising a store. In our example, we start with an
+empty configuration, which comes with `root` as a parameter. We can then
+instantiate the store and create a repo:
 
 ```ocaml skip
 let config ?(config = Irmin.Private.Conf.empty) ?root () =
@@ -302,7 +353,9 @@ let _repo = Store.Repo.v (config ())
 
 ## The Redis Server
 
-To test this example we also need a Redis server running. We can start one from the command line using the default configuration, which runs the server on port 6379:
+To test this example we also need a Redis server running. We can start one from
+the command line using the default configuration, which runs the server on port
+6379:
 
 ```shell
 $ redis-server /usr/local/etc/redis.conf

--- a/data/tutorial/command-line.md
+++ b/data/tutorial/command-line.md
@@ -5,8 +5,7 @@ title: "Using the command-line"
 
 ## Installation
 
-These examples requires the `irmin-unix` package to be installed from
-[opam](https://github.com/ocaml/opam):
+These examples requires the `irmin-unix` package to be installed from [opam]:
 
 ```shell
 $ opam install irmin-unix
@@ -89,10 +88,8 @@ See the output of `irmin help irmin.yml` for a list of configurable parameters.
 
 ### Customization
 
-It is possible to extend the `irmin` executable using
-[Irmin_unix.Resolver](https://mirage.github.io/irmin/irmin-unix/Irmin_unix/Resolver/index.html)
-and
-[Irmin_unix.Cli](https://mirage.github.io/irmin/irmin-unix/Irmin_unix/Cli/index.html):
+It is possible to extend the `irmin` executable using [Irmin_unix.Resolver] and
+[Irmin_unix.Cli]:
 
 ```ocaml
 module Cli = Irmin_unix.Cli
@@ -108,8 +105,8 @@ let () =
 
 ## Starting a GraphQL server
 
-`irmin` comes with a built-in [GraphQL](https://graphql.org) server, which can
-be used to easily query/modify a store remotely:
+`irmin` comes with a built-in [GraphQL] server, which can be used to easily
+query/modify a store remotely:
 
 ```shell
 $ irmin graphql --port 8080
@@ -182,3 +179,10 @@ As you can see, the command-line application has many capabilities, but it's
 just a fraction of what's available when using Irmin from OCaml! For more
 information about using Irmin and OCaml, check out the
 [next section](GettingStartedOCaml.html).
+
+<!-- prettier-ignore-start -->
+[Irmin_unix.Resolver]: https://mirage.github.io/irmin/irmin-unix/Irmin_unix/Resolver/index.html
+[Irmin_unix.Cli]: https://mirage.github.io/irmin/irmin-unix/Irmin_unix/Cli/index.html
+[GraphQL]: https://graphql.org
+[opam]: https://github.com/ocaml/opam
+<!-- prettier-ignore-end -->

--- a/data/tutorial/command-line.md
+++ b/data/tutorial/command-line.md
@@ -5,13 +5,15 @@ title: "Using the command-line"
 
 ## Installation
 
-These examples requires the `irmin-unix` package to be installed from [opam](https://github.com/ocaml/opam):
+These examples requires the `irmin-unix` package to be installed from
+[opam](https://github.com/ocaml/opam):
 
 ```shell
 $ opam install irmin-unix
 ```
 
-After that is finished you should have the `irmin` binary installed! To get a list of commands run:
+After that is finished you should have the `irmin` binary installed! To get a
+list of commands run:
 
 ```shell
 $ irmin help
@@ -37,7 +39,9 @@ My value
 $ irmin remove -s git --root $EXAMPLE "My key"
 ```
 
-We can also list the contents of the store in a couple of ways. `irmin tree` is used to inspect the contents of the store and `irmin list $KEY` is used to list the contents under a specific path.
+We can also list the contents of the store in a couple of ways. `irmin tree` is
+used to inspect the contents of the store and `irmin list $KEY` is used to list
+the contents under a specific path.
 
 ```shell
 $ irmin set -s git --root $EXAMPLE a/b/c 123
@@ -56,7 +60,9 @@ $ irmin tree -s git --root $EXAMPLE
 
 ## Configuration
 
-If you get sick of passing around `--root` all the time, you can create a configuration file called `./irmin.yml` or `~/.irmin/config.yml` with global configuration options:
+If you get sick of passing around `--root` all the time, you can create a
+configuration file called `./irmin.yml` or `~/.irmin/config.yml` with global
+configuration options:
 
 ```yaml
 root: /tmp/irmin/example
@@ -83,7 +89,10 @@ See the output of `irmin help irmin.yml` for a list of configurable parameters.
 
 ### Customization
 
-It is possible to extend the `irmin` executable using [Irmin_unix.Resolver](https://mirage.github.io/irmin/irmin-unix/Irmin_unix/Resolver/index.html) and [Irmin_unix.Cli](https://mirage.github.io/irmin/irmin-unix/Irmin_unix/Cli/index.html):
+It is possible to extend the `irmin` executable using
+[Irmin_unix.Resolver](https://mirage.github.io/irmin/irmin-unix/Irmin_unix/Resolver/index.html)
+and
+[Irmin_unix.Cli](https://mirage.github.io/irmin/irmin-unix/Irmin_unix/Cli/index.html):
 
 ```ocaml
 module Cli = Irmin_unix.Cli
@@ -99,7 +108,8 @@ let () =
 
 ## Starting a GraphQL server
 
-`irmin` comes with a built-in [GraphQL](https://graphql.org) server, which can be used to easily query/modify a store remotely:
+`irmin` comes with a built-in [GraphQL](https://graphql.org) server, which can
+be used to easily query/modify a store remotely:
 
 ```shell
 $ irmin graphql --port 8080
@@ -112,7 +122,10 @@ $ curl http://localhost:8080/graphql -d '{"query": "query { master { head { hash
 {"data":{"master":{"head":{"hash":"2a16cd7d8e27d134e6194140617d25d977441396"}}}}
 ```
 
-You can also visit [http://localhost:8080/graphql](http://localhost:8080/graphql) for an interactive environment for writing GraphQL queries. Of course, you're also free to use your GraphQL client of choice!
+You can also visit
+[http://localhost:8080/graphql](http://localhost:8080/graphql) for an
+interactive environment for writing GraphQL queries. Of course, you're also free
+to use your GraphQL client of choice!
 
 ## Snapshot/revert
 
@@ -131,7 +144,9 @@ $ irmin revert 7941ae769181f4fbf5056d8b2bfe1cd8e10928bd
 
 ## Git compatibility
 
-`irmin` and `git` can be used interchangeably to inspect and modify a repository. For instance, here are some examples of operations that can be achieved using either `git` or `irmin`.
+`irmin` and `git` can be used interchangeably to inspect and modify a
+repository. For instance, here are some examples of operations that can be
+achieved using either `git` or `irmin`.
 
 ### Cloning a remote repository
 
@@ -163,4 +178,7 @@ $ irmin push -s git $GIT_REPO_URL
 $ git push $GIT_REPO_URL master
 ```
 
-As you can see, the command-line application has many capabilities, but it's just a fraction of what's available when using Irmin from OCaml! For more information about using Irmin and OCaml, check out the [next section](GettingStartedOCaml.html).
+As you can see, the command-line application has many capabilities, but it's
+just a fraction of what's available when using Irmin from OCaml! For more
+information about using Irmin and OCaml, check out the
+[next section](GettingStartedOCaml.html).

--- a/data/tutorial/contents.md
+++ b/data/tutorial/contents.md
@@ -7,15 +7,13 @@ At some point working with `Irmin` you will probably want to move beyond using
 the default content types.
 
 This section will explain how custom datatypes can be implemented using
-[Irmin.Type](https://mirage.github.io/irmin/irmin/Irmin/Type/index.html). Before
-continuing with these examples make sure to read through the
-[official documentation](https://docs.mirage.io/irmin/Irmin/Type/index.html),
-which has information about the predefined types and how they're used.
+[Irmin.Type][irmin.type]. Before continuing with these examples make sure to
+read through the [official documentation][irmin.type], which has information
+about the predefined types and how they're used.
 
 Now that you've read through the documentation, let's create some contents by
-defining the functions required by the
-[Irmin.Contents.S](https://docs.mirage.io/irmin/Irmin/Contents/module-type-S/index.html)
-interface. This section will walk you through a few different examples:
+defining the functions required by the [Irmin.Contents.S] interface. This
+section will walk you through a few different examples:
 
 - [Counter](#counter)
 - [Record](#record)
@@ -36,10 +34,8 @@ A counter is just a simple `int64` value that can be incremented and
 decremented, when counters are merged the values will be added together.
 
 To get started, you will need to define a type `t` and build a value `t` using
-the functions provided in
-[Irmin.Type](https://docs.mirage.io/irmin/Irmin/Type/index.html). In this case
-all we need is the existing `int64` value, but in most cases it won't be this
-simple!
+the functions provided in [Irmin.Type]. In this case all we need is the existing
+`int64` value, but in most cases it won't be this simple!
 
 ```ocaml
 module Counter: Irmin.Contents.S with type t = int64 = struct
@@ -48,9 +44,8 @@ module Counter: Irmin.Contents.S with type t = int64 = struct
 ```
 
 Now we need to define a merge function. There is already a `counter`
-implementation available in
-[Irmin.Merge](https://docs.mirage.io/irmin/Irmin/Merge/index.html), so you
-wouldn't actually need to write this yourself:
+implementation available in [Irmin.Merge][irmin.merge], so you wouldn't actually
+need to write this yourself:
 
 ```ocaml
 	let merge ~old a b =
@@ -99,8 +94,7 @@ type car = {
 ```
 
 First, `color` has to be wrapped. Variants are modeled using the
-[variant](https://mirage.github.io/irmin/irmin/Irmin/Type/index.html#val-variant)
-function:
+[variant][irmin.type-variant] function:
 
 ```ocaml
 module Car = struct
@@ -202,9 +196,8 @@ simplifies this process for association lists. In this example we are using
 strings for both the keys and values, however in most other cases `alist` can
 get a bit more complicated since it requires existing merge functions for both
 the key and value types. For a slightly more complicated example you can read
-through `merge_object` and `merge_value` in
-[contents.ml](https://github.com/mirage/irmin/blob/master/src/irmin/contents.ml),
-which are used to implement JSON contents for Irmin.
+through `merge_object` and `merge_value` in [contents.ml][irmin.contents], which
+are used to implement JSON contents for Irmin.
 
 ```ocaml
     let merge_alist =
@@ -301,6 +294,16 @@ let main =
 let () = Lwt_main.run main
 ```
 
-If you'd like another example then check out the
-[custom merge](https://github.com/mirage/irmin/blob/master/examples/custom_merge.ml)
-example in the Irmin repository, which illustrates how to write a mergeable log.
+If you'd like another example then check out the [custom
+merge][examples/custom-merge] example in the Irmin repository, which illustrates
+how to write a mergeable log.
+
+<!-- prettier-ignore-start -->
+[irmin.type]: https://mirage.github.io/irmin/irmin/Irmin/Type/index.html
+[irmin.type-variant]: https://mirage.github.io/irmin/irmin/Irmin/Type/index.html#val-variant
+[irmin.contents]: https://github.com/mirage/irmin/blob/master/src/irmin/contents.ml
+[irmin.contents.s]: https://docs.mirage.io/irmin/Irmin/Contents/module-type-S/index.html
+[irmin.merge]: https://docs.mirage.io/irmin/Irmin/Merge/index.html
+
+[examples/custom-merge]: https://github.com/mirage/irmin/blob/master/examples/custom_merge.ml
+<!-- prettier-ignore-end -->

--- a/data/tutorial/contents.md
+++ b/data/tutorial/contents.md
@@ -3,11 +3,19 @@ path: "/tutorial/contents"
 title: "Custom content types"
 ---
 
-At some point working with `Irmin` you will probably want to move beyond using the default content types.
+At some point working with `Irmin` you will probably want to move beyond using
+the default content types.
 
-This section will explain how custom datatypes can be implemented using [Irmin.Type](https://mirage.github.io/irmin/irmin/Irmin/Type/index.html). Before continuing with these examples make sure to read through the [official documentation](https://docs.mirage.io/irmin/Irmin/Type/index.html), which has information about the predefined types and how they're used.
+This section will explain how custom datatypes can be implemented using
+[Irmin.Type](https://mirage.github.io/irmin/irmin/Irmin/Type/index.html). Before
+continuing with these examples make sure to read through the
+[official documentation](https://docs.mirage.io/irmin/Irmin/Type/index.html),
+which has information about the predefined types and how they're used.
 
-Now that you've read through the documentation, let's create some contents by defining the functions required by the [Irmin.Contents.S](https://docs.mirage.io/irmin/Irmin/Contents/module-type-S/index.html) interface. This section will walk you through a few different examples:
+Now that you've read through the documentation, let's create some contents by
+defining the functions required by the
+[Irmin.Contents.S](https://docs.mirage.io/irmin/Irmin/Contents/module-type-S/index.html)
+interface. This section will walk you through a few different examples:
 
 - [Counter](#counter)
 - [Record](#record)
@@ -24,9 +32,14 @@ To create a content type you need to define the following:
 
 ## Counter
 
-A counter is just a simple `int64` value that can be incremented and decremented, when counters are merged the values will be added together.
+A counter is just a simple `int64` value that can be incremented and
+decremented, when counters are merged the values will be added together.
 
-To get started, you will need to define a type `t` and build a value `t` using the functions provided in [Irmin.Type](https://docs.mirage.io/irmin/Irmin/Type/index.html). In this case all we need is the existing `int64` value, but in most cases it won't be this simple!
+To get started, you will need to define a type `t` and build a value `t` using
+the functions provided in
+[Irmin.Type](https://docs.mirage.io/irmin/Irmin/Type/index.html). In this case
+all we need is the existing `int64` value, but in most cases it won't be this
+simple!
 
 ```ocaml
 module Counter: Irmin.Contents.S with type t = int64 = struct
@@ -34,7 +47,10 @@ module Counter: Irmin.Contents.S with type t = int64 = struct
 	let t = Irmin.Type.int64
 ```
 
-Now we need to define a merge function. There is already a `counter` implementation available in [Irmin.Merge](https://docs.mirage.io/irmin/Irmin/Merge/index.html), so you wouldn't actually need to write this yourself:
+Now we need to define a merge function. There is already a `counter`
+implementation available in
+[Irmin.Merge](https://docs.mirage.io/irmin/Irmin/Merge/index.html), so you
+wouldn't actually need to write this yourself:
 
 ```ocaml
 	let merge ~old a b =
@@ -82,7 +98,9 @@ type car = {
 }
 ```
 
-First, `color` has to be wrapped. Variants are modeled using the [variant](https://mirage.github.io/irmin/irmin/Irmin/Type/index.html#val-variant) function:
+First, `color` has to be wrapped. Variants are modeled using the
+[variant](https://mirage.github.io/irmin/irmin/Irmin/Type/index.html#val-variant)
+function:
 
 ```ocaml
 module Car = struct
@@ -99,7 +117,8 @@ module Car = struct
         |> sealv
 ```
 
-This is mapping variant cases to their names in string representation. Records are handled similarly:
+This is mapping variant cases to their names in string representation. Records
+are handled similarly:
 
 ```ocaml
     let t =
@@ -121,7 +140,9 @@ Here's the merge operation:
 end
 ```
 
-Now some examples using `Car` -- we will map Vehicle Identification Number to a car record, this could be used by a tow company or an auto shop to identify cars:
+Now some examples using `Car` -- we will map Vehicle Identification Number to a
+car record, this could be used by a tow company or an auto shop to identify
+cars:
 
 ```ocaml
 open Lwt.Infix
@@ -161,9 +182,12 @@ let () = Lwt_main.run main
 
 ## Association list
 
-In this example we will define an association list that maps string keys to string values. The type itself is not very complicated, but the merge function is even more complex than the previous two examples.
+In this example we will define an association list that maps string keys to
+string values. The type itself is not very complicated, but the merge function
+is even more complex than the previous two examples.
 
-Like the two examples above, you need to define a `t` type and a `t` value of type `Irmin.Type.t` to begin:
+Like the two examples above, you need to define a `t` type and a `t` value of
+type `Irmin.Type.t` to begin:
 
 ```ocaml
 module Object = struct
@@ -173,7 +197,14 @@ module Object = struct
 
 So far so good, Irmin provides a simple way to model a list of pairs!
 
-To write the merge function we can leverage `Irmin.Merge.alist`, which simplifies this process for association lists. In this example we are using strings for both the keys and values, however in most other cases `alist` can get a bit more complicated since it requires existing merge functions for both the key and value types. For a slightly more complicated example you can read through `merge_object` and `merge_value` in [contents.ml](https://github.com/mirage/irmin/blob/master/src/irmin/contents.ml), which are used to implement JSON contents for Irmin.
+To write the merge function we can leverage `Irmin.Merge.alist`, which
+simplifies this process for association lists. In this example we are using
+strings for both the keys and values, however in most other cases `alist` can
+get a bit more complicated since it requires existing merge functions for both
+the key and value types. For a slightly more complicated example you can read
+through `merge_object` and `merge_value` in
+[contents.ml](https://github.com/mirage/irmin/blob/master/src/irmin/contents.ml),
+which are used to implement JSON contents for Irmin.
 
 ```ocaml
     let merge_alist =
@@ -184,9 +215,12 @@ end
 
 ## LWW register
 
-A last-write-wins register is similar to a basic Irmin store, except on merge the most recently written value will be picked rather than trying to merge the values.
+A last-write-wins register is similar to a basic Irmin store, except on merge
+the most recently written value will be picked rather than trying to merge the
+values.
 
-First, this requires a way to get a timestamp -- we will make this as generic as possible so it can be used on Unix or MirageOS:
+First, this requires a way to get a timestamp -- we will make this as generic as
+possible so it can be used on Unix or MirageOS:
 
 ```ocaml
 module type TIMESTAMP = sig
@@ -217,7 +251,9 @@ A convenience function for adding a timestamp to a `C.t` value:
     let v c = (c, Time.now ())
 ```
 
-The merge operation for `Lww_register` is slightly different than the ones covered so far. It will not attempt to merge any values, instead it will pick the newest value based on the attached timestamp.
+The merge operation for `Lww_register` is slightly different than the ones
+covered so far. It will not attempt to merge any values, instead it will pick
+the newest value based on the attached timestamp.
 
 ```ocaml
     let merge ~old:_ (a, timestamp_a) (b, timestamp_b) =
@@ -265,4 +301,6 @@ let main =
 let () = Lwt_main.run main
 ```
 
-If you'd like another example then check out the [custom merge](https://github.com/mirage/irmin/blob/master/examples/custom_merge.ml) example in the Irmin repository, which illustrates how to write a mergeable log.
+If you'd like another example then check out the
+[custom merge](https://github.com/mirage/irmin/blob/master/examples/custom_merge.ml)
+example in the Irmin repository, which illustrates how to write a mergeable log.

--- a/data/tutorial/getting-started.md
+++ b/data/tutorial/getting-started.md
@@ -3,7 +3,19 @@ path: "/tutorial/getting-started"
 title: "Getting started with OCaml"
 ---
 
-When setting up an Irmin database in OCaml you will need to consider, at least, the content type and storage backend. This is because Irmin has the ability to adapt to existing data structures using a convenient type combinator ([Irmin.Type](https://mirage.github.io/irmin/irmin/Irmin/Type/index.html)), which is used to define [contents](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html) for your datastore. Irmin provides implementations for [String](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-String), [Cstruct](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Cstruct), [Json](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Json) and [Json_value](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Json_value) contents, but it is also very easy to make your own!
+When setting up an Irmin database in OCaml you will need to consider, at least,
+the content type and storage backend. This is because Irmin has the ability to
+adapt to existing data structures using a convenient type combinator
+([Irmin.Type](https://mirage.github.io/irmin/irmin/Irmin/Type/index.html)),
+which is used to define
+[contents](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html) for
+your datastore. Irmin provides implementations for
+[String](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-String),
+[Cstruct](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Cstruct),
+[Json](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Json)
+and
+[Json_value](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Json_value)
+contents, but it is also very easy to make your own!
 
 Irmin gives you a few options when it comes to storage:
 
@@ -11,11 +23,24 @@ Irmin gives you a few options when it comes to storage:
 - a filesystem store (`irmin-fs`)
 - git-compatible filesystem/in-memory stores (`irmin-git`)
 
-These packages define the way that the data should be organized, but not any I/O routines (with the exception of `irmin-mem`, which does no I/O). Luckily, `irmin-unix` implements the I/O routines needed to make Irmin work on Unix-like platforms. Additionally, the `irmin-mirage`, `irmin-mirage-git` and `irmin-mirage-graphql` packages provide [Mirage](https://mirage.io)-compatible interfaces.
+These packages define the way that the data should be organized, but not any I/O
+routines (with the exception of `irmin-mem`, which does no I/O). Luckily,
+`irmin-unix` implements the I/O routines needed to make Irmin work on Unix-like
+platforms. Additionally, the `irmin-mirage`, `irmin-mirage-git` and
+`irmin-mirage-graphql` packages provide [Mirage](https://mirage.io)-compatible
+interfaces.
 
-It's also possible to implement your own storage backend if you'd like -- nearly everything in `Irmin` is configurable thanks to the power of functors in OCaml! This includes the hash function, branch, key and metadata types. Because of this flexibility there are a lot of different options to pick from; I will do my best to explain the most basic usage in this section and begin introducing more advanced concepts in subsequent sections.
+It's also possible to implement your own storage backend if you'd like -- nearly
+everything in `Irmin` is configurable thanks to the power of functors in OCaml!
+This includes the hash function, branch, key and metadata types. Because of this
+flexibility there are a lot of different options to pick from; I will do my best
+to explain the most basic usage in this section and begin introducing more
+advanced concepts in subsequent sections.
 
-It is important to note that most Irmin functions return `Lwt.t` values, which means that you will need to use `Lwt_main.run` to execute them. If you're not familiar with [Lwt](https://github.com/ocsigen/lwt) then I suggest [this tutorial](https://mirage.io/wiki/tutorial-lwt).
+It is important to note that most Irmin functions return `Lwt.t` values, which
+means that you will need to use `Lwt_main.run` to execute them. If you're not
+familiar with [Lwt](https://github.com/ocsigen/lwt) then I suggest
+[this tutorial](https://mirage.io/wiki/tutorial-lwt).
 
 ## Creating a store
 
@@ -31,9 +56,14 @@ An on-disk git store with JSON contents:
 module Git_store = Irmin_unix.Git.FS.KV(Irmin.Contents.Json)
 ```
 
-These examples are using [Irmin.KV](https://mirage.github.io/irmin/irmin/Irmin/module-type-KV/index.html), which is a specialization of [Irmin.S](https://mirage.github.io/irmin/irmin/Irmin/module-type-S/index.html) with string list keys, string branches and no metadata.
+These examples are using
+[Irmin.KV](https://mirage.github.io/irmin/irmin/Irmin/module-type-KV/index.html),
+which is a specialization of
+[Irmin.S](https://mirage.github.io/irmin/irmin/Irmin/module-type-S/index.html)
+with string list keys, string branches and no metadata.
 
-The following example is the same as the first, using `Irmin_mem.Make` instead of `Irmin_mem.KV`:
+The following example is the same as the first, using `Irmin_mem.Make` instead
+of `Irmin_mem.KV`:
 
 ```ocaml
 module Mem_Store =
@@ -47,7 +77,13 @@ module Mem_Store =
 
 ## Configuring and creating a repo
 
-Different store types require different configuration options -- an on-disk store needs to know where it should be stored in the filesystem, however an in-memory store doesn't. This means that each storage backend implements its own configuration methods based on [Irmin.Private.Conf](https://mirage.github.io/irmin/irmin/Irmin/Private/Conf/index.html) -- for the examples above there are `Irmin_mem.config`, `Irmin_fs.config` and `Irmin_git.config`, each taking slightly different parameters.
+Different store types require different configuration options -- an on-disk
+store needs to know where it should be stored in the filesystem, however an
+in-memory store doesn't. This means that each storage backend implements its own
+configuration methods based on
+[Irmin.Private.Conf](https://mirage.github.io/irmin/irmin/Irmin/Private/Conf/index.html)
+-- for the examples above there are `Irmin_mem.config`, `Irmin_fs.config` and
+`Irmin_git.config`, each taking slightly different parameters.
 
 ```ocaml
 let git_config = Irmin_git.config ~bare:true "/tmp/irmin"
@@ -57,7 +93,9 @@ let git_config = Irmin_git.config ~bare:true "/tmp/irmin"
 let config = Irmin_mem.config ()
 ```
 
-With this configuration it's very easy to create an [Irmin.Repo](https://mirage.github.io/irmin/irmin/Irmin/Repo/index.html) using [Repo.v](https://mirage.github.io/irmin/irmin/Irmin/Make/Repo/index.html#val-v):
+With this configuration it's very easy to create an
+[Irmin.Repo](https://mirage.github.io/irmin/irmin/Irmin/Repo/index.html) using
+[Repo.v](https://mirage.github.io/irmin/irmin/Irmin/Make/Repo/index.html#val-v):
 
 ```ocaml
 let git_repo = Git_store.Repo.v git_config
@@ -107,7 +145,10 @@ let () = Lwt_main.run main
 
 ## Transactions
 
-[Transactions](https://mirage.github.io/irmin/irmin/Irmin/module-type-S_MAKER/index.html#type-transaction) allow you to make many modifications using an in-memory tree then apply them all at once. This is done using [with_tree](https://mirage.github.io/irmin/irmin/Irmin/module-type-S_MAKER/index.html#val-with_tree):
+[Transactions](https://mirage.github.io/irmin/irmin/Irmin/module-type-S_MAKER/index.html#type-transaction)
+allow you to make many modifications using an in-memory tree then apply them all
+at once. This is done using
+[with_tree](https://mirage.github.io/irmin/irmin/Irmin/module-type-S_MAKER/index.html#val-with_tree):
 
 ```ocaml
 let transaction_example =
@@ -121,7 +162,11 @@ Mem_store.with_tree_exn t [] ~info ~strategy:`Set (fun tree ->
 let () = Lwt_main.run transaction_example
 ```
 
-A tree can be modified using the functions in [Irmin.S.Tree](https://mirage.github.io/irmin/irmin/Irmin/module-type-S/Tree/index.html), and when it is returned by the `with_tree` callback, it will be applied using the transaction's strategy (`` `Set `` in the code above) at the given key (`[]` in the code above).
+A tree can be modified using the functions in
+[Irmin.S.Tree](https://mirage.github.io/irmin/irmin/Irmin/module-type-S/Tree/index.html),
+and when it is returned by the `with_tree` callback, it will be applied using
+the transaction's strategy (`` `Set `` in the code above) at the given key (`[]`
+in the code above).
 
 Here is an example `move` function to move files from one path to another:
 
@@ -144,13 +189,18 @@ let () = Lwt_main.run main
 
 ## Sync
 
-[Irmin.Sync](https://docs.mirage.io/irmin/Irmin/Sync/index.html) implements the functions needed to interact with remote stores.
+[Irmin.Sync](https://docs.mirage.io/irmin/Irmin/Sync/index.html) implements the
+functions needed to interact with remote stores.
 
-- [fetch](https://docs.mirage.io/irmin/Irmin/Sync/index.html#val-fetch) populates a local store with objects from a remote store
-- [pull](https://docs.mirage.io/irmin/Irmin/Sync/index.html#val-pull) updates a local store with objects from a remote store
-- [push](https://docs.mirage.io/irmin/Irmin/Sync/index.html#val-fpush) updates a remote store with objects from a local store
+- [fetch](https://docs.mirage.io/irmin/Irmin/Sync/index.html#val-fetch)
+  populates a local store with objects from a remote store
+- [pull](https://docs.mirage.io/irmin/Irmin/Sync/index.html#val-pull) updates a
+  local store with objects from a remote store
+- [push](https://docs.mirage.io/irmin/Irmin/Sync/index.html#val-fpush) updates a
+  remote store with objects from a local store
 
-Each of these also has an `_exn` variant which may raise an exception instead of returning `result` value.
+Each of these also has an `_exn` variant which may raise an exception instead of
+returning `result` value.
 
 For example, you can pull a repo and list the files in the root of the project:
 
@@ -172,9 +222,15 @@ let () = Lwt_main.run main
 
 ## JSON Contents
 
-Most examples in this tutorial use string contents, so I will provide some further information about using JSON values.
+Most examples in this tutorial use string contents, so I will provide some
+further information about using JSON values.
 
-There are two types of JSON contents: [Json_value](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Json_value) and [Json](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Json), where `Json` can only store JSON objects and `Json_value` works with any JSON value.
+There are two types of JSON contents:
+[Json_value](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Json_value)
+and
+[Json](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Json),
+where `Json` can only store JSON objects and `Json_value` works with any JSON
+value.
 
 Setting up the store is exactly the same as when working with strings:
 
@@ -183,7 +239,8 @@ module Mem_store_json = Irmin_mem.KV(Irmin.Contents.Json)
 module Mem_store_json_value = Irmin_mem.KV(Irmin.Contents.Json_value)
 ```
 
-For example, using `Men_store_json_value` we can assign `{"x": 1, "y": 2, "z": 3}` to the key `a/b/c`:
+For example, using `Men_store_json_value` we can assign
+`{"x": 1, "y": 2, "z": 3}` to the key `a/b/c`:
 
 ```ocaml
 let main =
@@ -196,9 +253,18 @@ let main =
 let () = Lwt_main.run main
 ```
 
-An interesting thing about `Json_value` stores is the ability to use [Json_tree](https://mirage.github.io/irmin/irmin/Irmin/index.html#module-Json_tree) to recursively project values onto a key. This means that using `Json_tree.set`, to assign `{"test": {"foo": "bar"}, "x": 1, "y": 2, "z": 3}` to the key `a/b/c` will set `a/b/c/x` to `1`, `a/b/c/y` to `2`, `a/b/c/z` to `3` and `a/b/c/test/foo` to `"bar"`.
+An interesting thing about `Json_value` stores is the ability to use
+[Json_tree](https://mirage.github.io/irmin/irmin/Irmin/index.html#module-Json_tree)
+to recursively project values onto a key. This means that using `Json_tree.set`,
+to assign `{"test": {"foo": "bar"}, "x": 1, "y": 2, "z": 3}` to the key `a/b/c`
+will set `a/b/c/x` to `1`, `a/b/c/y` to `2`, `a/b/c/z` to `3` and
+`a/b/c/test/foo` to `"bar"`.
 
-This allows for large JSON objects to be modified in pieces without having the encode/decode the entire thing to access specific fields. Using `Json_tree.get` we can also retrieve a tree as a JSON value. So if we call `Json_tree.get` with the key `a/b` we will get the following object back: `{"c": {"test": {"foo": "bar"}, "x": 1, "y": 2, "z": 3}}`.
+This allows for large JSON objects to be modified in pieces without having the
+encode/decode the entire thing to access specific fields. Using `Json_tree.get`
+we can also retrieve a tree as a JSON value. So if we call `Json_tree.get` with
+the key `a/b` we will get the following object back:
+`{"c": {"test": {"foo": "bar"}, "x": 1, "y": 2, "z": 3}}`.
 
 ```ocaml
 let main =

--- a/data/tutorial/getting-started.md
+++ b/data/tutorial/getting-started.md
@@ -6,16 +6,10 @@ title: "Getting started with OCaml"
 When setting up an Irmin database in OCaml you will need to consider, at least,
 the content type and storage backend. This is because Irmin has the ability to
 adapt to existing data structures using a convenient type combinator
-([Irmin.Type](https://mirage.github.io/irmin/irmin/Irmin/Type/index.html)),
-which is used to define
-[contents](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html) for
-your datastore. Irmin provides implementations for
-[String](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-String),
-[Cstruct](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Cstruct),
-[Json](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Json)
-and
-[Json_value](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Json_value)
-contents, but it is also very easy to make your own!
+([Irmin.Type]), which is used to define [contents][irmin.contents] for your
+datastore. Irmin provides implementations for [String][irmin.contents.string],
+[Cstruct][irmin.contents.cstruct], [Json] and [Json_value] contents, but it is
+also very easy to make your own!
 
 Irmin gives you a few options when it comes to storage:
 
@@ -27,8 +21,7 @@ These packages define the way that the data should be organized, but not any I/O
 routines (with the exception of `irmin-mem`, which does no I/O). Luckily,
 `irmin-unix` implements the I/O routines needed to make Irmin work on Unix-like
 platforms. Additionally, the `irmin-mirage`, `irmin-mirage-git` and
-`irmin-mirage-graphql` packages provide [Mirage](https://mirage.io)-compatible
-interfaces.
+`irmin-mirage-graphql` packages provide [Mirage][mirage]-compatible interfaces.
 
 It's also possible to implement your own storage backend if you'd like -- nearly
 everything in `Irmin` is configurable thanks to the power of functors in OCaml!
@@ -39,8 +32,7 @@ advanced concepts in subsequent sections.
 
 It is important to note that most Irmin functions return `Lwt.t` values, which
 means that you will need to use `Lwt_main.run` to execute them. If you're not
-familiar with [Lwt](https://github.com/ocsigen/lwt) then I suggest
-[this tutorial](https://mirage.io/wiki/tutorial-lwt).
+familiar with [Lwt][lwt] then I suggest [this tutorial][lwt-tutorial].
 
 ## Creating a store
 
@@ -56,11 +48,8 @@ An on-disk git store with JSON contents:
 module Git_store = Irmin_unix.Git.FS.KV(Irmin.Contents.Json)
 ```
 
-These examples are using
-[Irmin.KV](https://mirage.github.io/irmin/irmin/Irmin/module-type-KV/index.html),
-which is a specialization of
-[Irmin.S](https://mirage.github.io/irmin/irmin/Irmin/module-type-S/index.html)
-with string list keys, string branches and no metadata.
+These examples are using [Irmin.KV][irmin.kv], which is a specialization of
+[Irmin.S][irmin.s] with string list keys, string branches and no metadata.
 
 The following example is the same as the first, using `Irmin_mem.Make` instead
 of `Irmin_mem.KV`:
@@ -80,10 +69,9 @@ module Mem_Store =
 Different store types require different configuration options -- an on-disk
 store needs to know where it should be stored in the filesystem, however an
 in-memory store doesn't. This means that each storage backend implements its own
-configuration methods based on
-[Irmin.Private.Conf](https://mirage.github.io/irmin/irmin/Irmin/Private/Conf/index.html)
--- for the examples above there are `Irmin_mem.config`, `Irmin_fs.config` and
-`Irmin_git.config`, each taking slightly different parameters.
+configuration methods based on [Irmin.Private.Conf] -- for the examples above
+there are `Irmin_mem.config`, `Irmin_fs.config` and `Irmin_git.config`, each
+taking slightly different parameters.
 
 ```ocaml
 let git_config = Irmin_git.config ~bare:true "/tmp/irmin"
@@ -93,9 +81,8 @@ let git_config = Irmin_git.config ~bare:true "/tmp/irmin"
 let config = Irmin_mem.config ()
 ```
 
-With this configuration it's very easy to create an
-[Irmin.Repo](https://mirage.github.io/irmin/irmin/Irmin/Repo/index.html) using
-[Repo.v](https://mirage.github.io/irmin/irmin/Irmin/Make/Repo/index.html#val-v):
+With this configuration it's very easy to create an [Irmin.Repo] using
+[Repo.v][irmin.repo.v]:
 
 ```ocaml
 let git_repo = Git_store.Repo.v git_config
@@ -145,10 +132,9 @@ let () = Lwt_main.run main
 
 ## Transactions
 
-[Transactions](https://mirage.github.io/irmin/irmin/Irmin/module-type-S_MAKER/index.html#type-transaction)
-allow you to make many modifications using an in-memory tree then apply them all
-at once. This is done using
-[with_tree](https://mirage.github.io/irmin/irmin/Irmin/module-type-S_MAKER/index.html#val-with_tree):
+[Transactions][irmin.s-transaction] allow you to make many modifications using
+an in-memory tree then apply them all at once. This is done using
+[with_tree][irmin.s-with_tree]:
 
 ```ocaml
 let transaction_example =
@@ -162,11 +148,10 @@ Mem_store.with_tree_exn t [] ~info ~strategy:`Set (fun tree ->
 let () = Lwt_main.run transaction_example
 ```
 
-A tree can be modified using the functions in
-[Irmin.S.Tree](https://mirage.github.io/irmin/irmin/Irmin/module-type-S/Tree/index.html),
-and when it is returned by the `with_tree` callback, it will be applied using
-the transaction's strategy (`` `Set `` in the code above) at the given key (`[]`
-in the code above).
+A tree can be modified using the functions in [Irmin.S.Tree][irmin.s.tree], and
+when it is returned by the `with_tree` callback, it will be applied using the
+transaction's strategy (`` `Set `` in the code above) at the given key (`[]` in
+the code above).
 
 Here is an example `move` function to move files from one path to another:
 
@@ -189,15 +174,12 @@ let () = Lwt_main.run main
 
 ## Sync
 
-[Irmin.Sync](https://docs.mirage.io/irmin/Irmin/Sync/index.html) implements the
-functions needed to interact with remote stores.
+[Irmin.Sync] implements the functions needed to interact with remote stores.
 
-- [fetch](https://docs.mirage.io/irmin/Irmin/Sync/index.html#val-fetch)
-  populates a local store with objects from a remote store
-- [pull](https://docs.mirage.io/irmin/Irmin/Sync/index.html#val-pull) updates a
-  local store with objects from a remote store
-- [push](https://docs.mirage.io/irmin/Irmin/Sync/index.html#val-fpush) updates a
-  remote store with objects from a local store
+- [fetch][irmin.sync.fetch] populates a local store with objects from a remote
+  store
+- [pull][irmin.sync.pull] updates a local store with objects from a remote store
+- [push][irmin.sync.push] updates a remote store with objects from a local store
 
 Each of these also has an `_exn` variant which may raise an exception instead of
 returning `result` value.
@@ -225,12 +207,8 @@ let () = Lwt_main.run main
 Most examples in this tutorial use string contents, so I will provide some
 further information about using JSON values.
 
-There are two types of JSON contents:
-[Json_value](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Json_value)
-and
-[Json](https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Json),
-where `Json` can only store JSON objects and `Json_value` works with any JSON
-value.
+There are two types of JSON contents: [Json_value] and [Json], where `Json` can
+only store JSON objects and `Json_value` works with any JSON value.
 
 Setting up the store is exactly the same as when working with strings:
 
@@ -253,8 +231,7 @@ let main =
 let () = Lwt_main.run main
 ```
 
-An interesting thing about `Json_value` stores is the ability to use
-[Json_tree](https://mirage.github.io/irmin/irmin/Irmin/index.html#module-Json_tree)
+An interesting thing about `Json_value` stores is the ability to use [Json_tree]
 to recursively project values onto a key. This means that using `Json_tree.set`,
 to assign `{"test": {"foo": "bar"}, "x": 1, "y": 2, "z": 3}` to the key `a/b/c`
 will set `a/b/c/x` to `1`, `a/b/c/y` to `2`, `a/b/c/z` to `3` and
@@ -281,3 +258,29 @@ let main =
     assert (Irmin.Type.equal Store.contents_t (`O ["c", value]) x)
 let () = Lwt_main.run main
 ```
+
+<!-- prettier-ignore-start -->
+[irmin.kv]: https://mirage.github.io/irmin/irmin/Irmin/module-type-KV/index.html
+[irmin.s]: https://mirage.github.io/irmin/irmin/Irmin/module-type-S/index.html
+[irmin.s-transaction]: https://mirage.github.io/irmin/irmin/Irmin/module-type-S_MAKER/index.html#type-transaction
+[irmin.s-with_tree]: https://mirage.github.io/irmin/irmin/Irmin/module-type-S_MAKER/index.html#val-with_tree
+[irmin.s.tree]: https://mirage.github.io/irmin/irmin/Irmin/module-type-S/Tree/index.html
+[irmin.type]: https://mirage.github.io/irmin/irmin/Irmin/Type/index.html
+[irmin.contents]: https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html
+[irmin.content.string]: https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-String
+[irmin.private.conf]: https://mirage.github.io/irmin/irmin/Irmin/Private/Conf/index.html
+[irmin.repo]: https://mirage.github.io/irmin/irmin/Irmin/module-type-S/Repo/index.html
+[irmin.repo.v]: https://mirage.github.io/irmin/irmin/Irmin/module-type-S/Repo/index.html#val-v
+[irmin.sync]: https://docs.mirage.io/irmin/Irmin/Sync/index.html
+[irmin.sync.fetch]: https://docs.mirage.io/irmin/Irmin/Sync/index.html#val-fetch
+[irmin.sync.pull]: https://docs.mirage.io/irmin/Irmin/Sync/index.html#val-pull
+[irmin.sync.push]: https://docs.mirage.io/irmin/Irmin/Sync/index.html#val-fpush
+
+[Json]: https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Json
+[Json_tree]: https://mirage.github.io/irmin/irmin/Irmin/index.html#module-Json_tree
+[Json_value]: https://mirage.github.io/irmin/irmin/Irmin/Contents/index.html#module-Json_value
+
+[mirage]: https://mirage.io
+[lwt]: https://github.com/ocsigen/lwt
+[lwt-tutorial]: https://mirage.io/wiki/tutorial-lwt
+<!-- prettier-ignore-end -->

--- a/data/tutorial/graphql.md
+++ b/data/tutorial/graphql.md
@@ -3,7 +3,10 @@ path: "/tutorial/graphql"
 title: "GraphQL bindings"
 ---
 
-`irmin-graphql` provides a nice interface for accessing remote Irmin stores over a network. This section will show you how to run an `irmin-graphql` server and query it using [irmin-js](https://github.com/zshipko/irmin-js), or your favorite GraphQL client!
+`irmin-graphql` provides a nice interface for accessing remote Irmin stores over
+a network. This section will show you how to run an `irmin-graphql` server and
+query it using [irmin-js](https://github.com/zshipko/irmin-js), or your favorite
+GraphQL client!
 
 ## Installation
 
@@ -21,26 +24,36 @@ To start the GraphQL server:
 $ irmin graphql --port 8080
 ```
 
-This will start the server on `localhost:8080` - this can be customized using the `--address` and `--port` flags. By default `irmin-graphql` provides an GraphiQL editor for writing queries from within the browser which can be accessed at [http://localhost:8080/graphql](http://localhost:8080/graphql).
+This will start the server on `localhost:8080` - this can be customized using
+the `--address` and `--port` flags. By default `irmin-graphql` provides an
+GraphiQL editor for writing queries from within the browser which can be
+accessed at [http://localhost:8080/graphql](http://localhost:8080/graphql).
 
 ## Available clients
 
-There are several reference client implementations which provide many basic queries by default, in addition to simplifying the process of executing handwritten queries.
+There are several reference client implementations which provide many basic
+queries by default, in addition to simplifying the process of executing
+handwritten queries.
 
 - [irmin-js](https://github.com/zshipko/irmin-js)
 - [irmin-go](https://github.com/zshipko/irmin-go)
 
 ## Schema
 
-Using the GraphiQL web interface you can explore the schema using the **Docs** button in the upper-right corner. Additionally, there are tools like [`get-graphql-schema`](https://github.com/prisma/get-graphql-schema) which will dump the entire schema for you.
+Using the GraphiQL web interface you can explore the schema using the **Docs**
+button in the upper-right corner. Additionally, there are tools like
+[`get-graphql-schema`](https://github.com/prisma/get-graphql-schema) which will
+dump the entire schema for you.
 
 ## Queries
 
-Using `irmin-graphql` it is possible to collect information about Irmin databases (and Git repositories) using GraphQL.
+Using `irmin-graphql` it is possible to collect information about Irmin
+databases (and Git repositories) using GraphQL.
 
 ### Get
 
-To start off we will create a query to retrieve the value stored at the path `abc`:
+To start off we will create a query to retrieve the value stored at the path
+`abc`:
 
 ```graphql
 query {
@@ -85,7 +98,8 @@ query {
 }
 ```
 
-It's also possible to set or update multiple keys using the `set_tree` and `update_tree` mutations. The following will set `/a` to "foo" and `/b` to "bar":
+It's also possible to set or update multiple keys using the `set_tree` and
+`update_tree` mutations. The following will set `/a` to "foo" and `/b` to "bar":
 
 ```graphql
 mutation {
@@ -115,7 +129,8 @@ this will set `a` to "testing" and remove the value associated with `b`.
 
 ### Branch info
 
-Using `master`/`branch` queries we are able to find lots of information about the attached Irmin store:
+Using `master`/`branch` queries we are able to find lots of information about
+the attached Irmin store:
 
 ```graphql
 query {
@@ -131,7 +146,9 @@ query {
 
 ### Bulk queries
 
-Due to difficulties representing infinitely recursive datatypes in GraphQL, an Irmin tree is represented using the `[TreeItem!]` type. `TreeItem` has the following keys:
+Due to difficulties representing infinitely recursive datatypes in GraphQL, an
+Irmin tree is represented using the `[TreeItem!]` type. `TreeItem` has the
+following keys:
 
 - `key`
 - `value`
@@ -175,7 +192,8 @@ query {
 
 ## Mutations
 
-`irmin-graphql` also supports mutations, which are basically queries with side-effects.
+`irmin-graphql` also supports mutations, which are basically queries with
+side-effects.
 
 ### Set
 
@@ -189,11 +207,14 @@ mutation {
 }
 ```
 
-The example above sets the key "a/b/c" (`["a"; "b"; "c"]` in OCaml) to "123" and returns the new commit's hash.
+The example above sets the key "a/b/c" (`["a"; "b"; "c"]` in OCaml) to "123" and
+returns the new commit's hash.
 
 ### Sync
 
-`clone`, `push` and `pull` are also supported as long as they're supported by the underlying store! This allows data to be synchronized across servers using a simple mutation:
+`clone`, `push` and `pull` are also supported as long as they're supported by
+the underlying store! This allows data to be synchronized across servers using a
+simple mutation:
 
 ```graphql
 mutation {
@@ -205,9 +226,11 @@ mutation {
 
 ### Bulk updates
 
-To update multiple values you can use `set_tree` and `update_tree`. The difference between the two is `set_tree` will modify
-the tree to match to provided tree, while `update_tree` will only modify the provided keys - updating the value if one is
-provided, otherwise removing the current value if `null` is provided. For example:
+To update multiple values you can use `set_tree` and `update_tree`. The
+difference between the two is `set_tree` will modify the tree to match to
+provided tree, while `update_tree` will only modify the provided keys - updating
+the value if one is provided, otherwise removing the current value if `null` is
+provided. For example:
 
 ```graphql
 mutation {
@@ -220,8 +243,9 @@ mutation {
 }
 ```
 
-will set `a/b/c` to `"123"` and `d/e/f` to "456", and if there are any other keys they will be removed. To keep the existing values,
-`update_tree` should be used:
+will set `a/b/c` to `"123"` and `d/e/f` to "456", and if there are any other
+keys they will be removed. To keep the existing values, `update_tree` should be
+used:
 
 ```graphql
 mutation {
@@ -238,14 +262,16 @@ mutation {
 }
 ```
 
-The above query will set the values of `a/b/c` and `d/e/f`, while removing the value associated with `testing` - all other values
-will be left as-is.
+The above query will set the values of `a/b/c` and `d/e/f`, while removing the
+value associated with `testing` - all other values will be left as-is.
 
 ## GraphQL servers in OCaml
 
-It is also possible to use the `irmin-graphql` OCaml interface to embed a GraphQL server in any application!
+It is also possible to use the `irmin-graphql` OCaml interface to embed a
+GraphQL server in any application!
 
-Using `Irmin_unix.Graphql.Server.Make` you can convert an existing `Irmin.S` typed module into a GraphQL server:
+Using `Irmin_unix.Graphql.Server.Make` you can convert an existing `Irmin.S`
+typed module into a GraphQL server:
 
 ```ocaml
 module Graphql_store = Irmin_unix.Git.Mem.KV(Irmin.Contents.String)
@@ -315,9 +341,12 @@ module Example_presenter = struct
 end
 ```
 
-(You may also opt to use `Irmin_graphql.Server.Default_presentation`, which can be used on any `Irmin.Type.S`)
+(You may also opt to use `Irmin_graphql.Server.Default_presentation`, which can
+be used on any `Irmin.Type.S`)
 
-Once you've done this for both the `contents` and `metadata` types you need to wrap them in `Irmin_graphql.Server.PRESENTATION` before passing them to `Irmin_graphql.Server.Make_ext`:
+Once you've done this for both the `contents` and `metadata` types you need to
+wrap them in `Irmin_graphql.Server.PRESENTATION` before passing them to
+`Irmin_graphql.Server.Make_ext`:
 
 ```ocaml
 module Example_store = Irmin_mem.KV(Example_type)

--- a/data/tutorial/graphql.md
+++ b/data/tutorial/graphql.md
@@ -5,8 +5,7 @@ title: "GraphQL bindings"
 
 `irmin-graphql` provides a nice interface for accessing remote Irmin stores over
 a network. This section will show you how to run an `irmin-graphql` server and
-query it using [irmin-js](https://github.com/zshipko/irmin-js), or your favorite
-GraphQL client!
+query it using [irmin-js], or your favorite GraphQL client!
 
 ## Installation
 
@@ -35,15 +34,14 @@ There are several reference client implementations which provide many basic
 queries by default, in addition to simplifying the process of executing
 handwritten queries.
 
-- [irmin-js](https://github.com/zshipko/irmin-js)
-- [irmin-go](https://github.com/zshipko/irmin-go)
+- [irmin-js]
+- [irmin-go]
 
 ## Schema
 
 Using the GraphiQL web interface you can explore the schema using the **Docs**
 button in the upper-right corner. Additionally, there are tools like
-[`get-graphql-schema`](https://github.com/prisma/get-graphql-schema) which will
-dump the entire schema for you.
+[`get-graphql-schema`] which will dump the entire schema for you.
 
 ## Queries
 
@@ -369,3 +367,9 @@ module Graphql_ext =
     (Example_store)
     (Presentation)
 ```
+
+<!-- prettier-ignore-start -->
+[irmin-js]: https://github.com/zshipko/irmin-js
+[irmin-go]: https://github.com/zshipko/irmin-go
+[get-graphql-schema]: https://github.com/prisma/get-graphql-schema
+<!-- prettier-ignore-end -->

--- a/data/tutorial/introduction.md
+++ b/data/tutorial/introduction.md
@@ -21,6 +21,6 @@ this tutorial then please file [an issue][irmin-issues]!
 
 <!-- prettier-ignore-start -->
 [irmin]: https://github.com/mirage/irmin
-[irmin-issues]: https://github.com/tarides/irmin.io/issues
+[irmin-issues]: https://github.com/mirage/irmin.io/issues
 [irmin-readme]: https://github.com/mirage/irmin/blob/master/README.md
 <!-- prettier-ignore-end -->

--- a/data/tutorial/introduction.md
+++ b/data/tutorial/introduction.md
@@ -3,10 +3,9 @@ path: "/tutorial/introduction"
 title: "Introduction"
 ---
 
-[Irmin](https://github.com/mirage/irmin) is a key-value store based on the same
-principles as Git. This means that for existing Git users it provides many
-familiar features: branching/merging, history and the ability to restore to any
-previous state.
+[Irmin] is a key-value store based on the same principles as Git. This means
+that for existing Git users it provides many familiar features:
+branching/merging, history and the ability to restore to any previous state.
 
 Typically Irmin is accessed by embedding it into an OCaml application, but can
 also be accessed using HTTP using `irmin-http` or GraphQL using `irmin-graphql`.
@@ -16,8 +15,12 @@ as a general purpose key-value store too. Additionally, since it is compatible
 with Git, Irmin can be used to interact with Git repositories directly from
 within your application.
 
-Take a moment to skim the
-[README](https://github.com/mirage/irmin/blob/master/README.md) to familiarize
-yourself with some of the concepts. Also, if you find that anything is missing
-or unclear in this tutorial then please file
-[an issue](https://github.com/tarides/irmin.io/issues)!
+Take a moment to skim the [README][irmin-readme] to familiarize yourself with
+some of the concepts. Also, if you find that anything is missing or unclear in
+this tutorial then please file [an issue][irmin-issues]!
+
+<!-- prettier-ignore-start -->
+[irmin]: https://github.com/mirage/irmin
+[irmin-issues]: https://github.com/tarides/irmin.io/issues
+[irmin-readme]: https://github.com/mirage/irmin/blob/master/README.md
+<!-- prettier-ignore-end -->

--- a/data/tutorial/introduction.md
+++ b/data/tutorial/introduction.md
@@ -3,8 +3,21 @@ path: "/tutorial/introduction"
 title: "Introduction"
 ---
 
-[Irmin](https://github.com/mirage/irmin) is a key-value store based on the same principles as Git. This means that for existing Git users it provides many familiar features: branching/merging, history and the ability to restore to any previous state.
+[Irmin](https://github.com/mirage/irmin) is a key-value store based on the same
+principles as Git. This means that for existing Git users it provides many
+familiar features: branching/merging, history and the ability to restore to any
+previous state.
 
-Typically Irmin is accessed by embedding it into an OCaml application, but can also be accessed using HTTP using `irmin-http` or GraphQL using `irmin-graphql`. It is most often used to store application data, like configuration values, shared state or checkpoint data, but there is nothing stopping you from using it as a general purpose key-value store too. Additionally, since it is compatible with Git, Irmin can be used to interact with Git repositories directly from within your application.
+Typically Irmin is accessed by embedding it into an OCaml application, but can
+also be accessed using HTTP using `irmin-http` or GraphQL using `irmin-graphql`.
+It is most often used to store application data, like configuration values,
+shared state or checkpoint data, but there is nothing stopping you from using it
+as a general purpose key-value store too. Additionally, since it is compatible
+with Git, Irmin can be used to interact with Git repositories directly from
+within your application.
 
-Take a moment to skim the [README](https://github.com/mirage/irmin/blob/master/README.md) to familiarize yourself with some of the concepts. Also, if you find that anything is missing or unclear in this tutorial then please file [an issue](https://github.com/tarides/irmin.io/issues)!
+Take a moment to skim the
+[README](https://github.com/mirage/irmin/blob/master/README.md) to familiarize
+yourself with some of the concepts. Also, if you find that anything is missing
+or unclear in this tutorial then please file
+[an issue](https://github.com/tarides/irmin.io/issues)!

--- a/data/tutorial/resources.md
+++ b/data/tutorial/resources.md
@@ -13,9 +13,12 @@ title: "Resources"
 ### Servers
 
 - [irmin-graphql](https://github.com/mirage/irmin) - A GraphQL server
-- [irmin-rpc](https://github.com/zshipko/irmin-rpc) - A capnproto-rpc client/server
-- [irmin-http](https://github.com/mirage/irmin) - A simple HTTP server that comes with `irmin-unix`
-- [irmin-web](https://github.com/zshipko/irmin-web) - A HTTP server with built-in Javascript bindings for communicating with `irmin-graphql`
+- [irmin-rpc](https://github.com/zshipko/irmin-rpc) - A capnproto-rpc
+  client/server
+- [irmin-http](https://github.com/mirage/irmin) - A simple HTTP server that
+  comes with `irmin-unix`
+- [irmin-web](https://github.com/zshipko/irmin-web) - A HTTP server with
+  built-in Javascript bindings for communicating with `irmin-graphql`
 
 ### Backends
 
@@ -23,8 +26,10 @@ title: "Resources"
 
 ### Language bindings
 
-- [irmin-js](https://github.com/zshipko/irmin-js) - Javascript bindings to `irmin-graphql`
-- [irmin-go](https://github.com/zshipko/irmin-go) - Go bindings to `irmin-graphql`
+- [irmin-js](https://github.com/zshipko/irmin-js) - Javascript bindings to
+  `irmin-graphql`
+- [irmin-go](https://github.com/zshipko/irmin-go) - Go bindings to
+  `irmin-graphql`
 
 ## Users of Irmin
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tarides/irmin.io"
+    "url": "https://github.com/mirage/irmin.io"
   }
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  proseWrap: "always"
+};


### PR DESCRIPTION
Fixes various self-referencing links in the tutorials/README.

Currently based on https://github.com/mirage/irmin.io/pull/21 (unmerged).