### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/irmin-website.opam
+++ b/irmin-website.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml"      {>= "4.06.0"}
-  "dune"       {build & >= "1.7.0"}
+  "dune"       {>= "1.7.0"}
   "irmin"
   "irmin-unix"
   "digestif"   {= "0.7.3"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.